### PR TITLE
Fix typos, clean template comment, add util tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,5 +10,4 @@ load_dotenv()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1"
 
-# Uncomment the line below to generate a new random secret key
-# print(secrets.token_hex(16))  # cuman buat generate code key
+# Only used to generate a secret key

--- a/templates/register.html
+++ b/templates/register.html
@@ -3,7 +3,6 @@
   <div class="flex items-center justify-center min-h-screen">
     <div class="bg-white shadow rounded p-8 w-full max-w-md">
       <h2 class="text-2xl font-bold mb-6 text-center">Register FestFlix</h2>
-      <!-- Tambahkan block untuk flash message (optional, biar rapi) -->
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
           {% for category, message in messages %}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import app
+
+
+def test_allowed_file_valid_image():
+    assert app.allowed_file("poster.jpg", app.ALLOWED_IMAGE_EXTENSIONS)
+
+def test_allowed_file_invalid_image():
+    assert not app.allowed_file("poster.txt", app.ALLOWED_IMAGE_EXTENSIONS)
+
+def test_allowed_file_valid_video():
+    assert app.allowed_file("movie.mp4", app.ALLOWED_VIDEO_EXTENSIONS)
+
+def test_allowed_file_invalid_video():
+    assert not app.allowed_file("movie.exe", app.ALLOWED_VIDEO_EXTENSIONS)


### PR DESCRIPTION
## Summary
- cleanup leftover debug line in `config.py`
- remove outdated flash message comment on register form
- test the `allowed_file` helper for valid and invalid filenames

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6843f437bce483218b8e026d4e288f28